### PR TITLE
UX: Add doc icons to sidebar items

### DIFF
--- a/assets/javascripts/discourse/lib/doc-category-sidebar-panel.js
+++ b/assets/javascripts/discourse/lib/doc-category-sidebar-panel.js
@@ -191,4 +191,12 @@ class DocCategorySidebarSectionLink extends BaseCustomSidebarSectionLink {
       navigation: this.#data.text.toLowerCase().split(/\s+/g),
     };
   }
+
+  get prefixType() {
+    return "icon";
+  }
+
+  get prefixValue() {
+    return "far-file";
+  }
 }

--- a/plugin.rb
+++ b/plugin.rb
@@ -14,6 +14,8 @@ register_asset "stylesheets/common.scss"
 
 GlobalSetting.add_default :docs_path, "docs"
 
+register_svg_icon "far-file"
+
 module ::DocCategories
   PLUGIN_NAME = "discourse-doc-categories"
 


### PR DESCRIPTION
Discourse's sidebar styling expects every item to have an icon. Without it, the indentation of section items looks strange.

Perhaps in future we could allow specifying an icon per-doc. Or maybe just re-style the sidebar to work ok without icons. But for now, this is the simplest fix.

Before:
<img width="550" alt="SCR-20240812-qauc" src="https://github.com/user-attachments/assets/e6b7f00d-ab23-48dc-b580-3eab418b8bc0">


After:
<img width="555" alt="SCR-20240812-qasj" src="https://github.com/user-attachments/assets/01e18d3f-6553-4d40-b343-6c48d30b0298">

