### PR TITLE
FIX: Error while updating the docs sidebar via message bus

### DIFF
--- a/assets/javascripts/discourse/services/doc-category-sidebar.js
+++ b/assets/javascripts/discourse/services/doc-category-sidebar.js
@@ -75,7 +75,7 @@ export default class DocCategorySidebarService extends Service {
   maybeUpdateIndexContent(data) {
     // if the docs sidebar is not displayed, tries to display it
     if (!this.isVisible) {
-      this.maybeForceDocsSidebar();
+      this.#maybeForceDocsSidebar();
       return;
     }
 


### PR DESCRIPTION
Fix small issue where an update to a docs category or index topic via message bus would cause an error to be logged in the console if the docs sidebar was not displayed.