### PR TITLE
DEV: Miscelaneous improvements

### DIFF
--- a/assets/javascripts/discourse/services/doc-category-sidebar.js
+++ b/assets/javascripts/discourse/services/doc-category-sidebar.js
@@ -19,12 +19,14 @@ export default class DocCategorySidebarService extends Service {
   constructor() {
     super(...arguments);
 
-    this.appEvents.on("page:changed", this, this.#maybeForceDocsSidebar);
+    this.router.on("routeDidChange", this, this.currentRouteChanged);
     this.messageBus.subscribe("/categories", this.maybeUpdateIndexContent);
   }
 
   willDestroy() {
     super.willDestroy(...arguments);
+
+    this.router.off("routeDidChange", this, this.currentRouteChanged);
     this.messageBus.unsubscribe("/categories", this.maybeUpdateIndexContent);
   }
 
@@ -95,6 +97,15 @@ export default class DocCategorySidebarService extends Service {
     if (data.deleted_categories?.find((id) => id === this._indexCategoryId)) {
       this.disableDocsSidebar();
     }
+  }
+
+  @bind
+  currentRouteChanged(transition) {
+    if (transition.isAborted) {
+      return;
+    }
+
+    this.#maybeForceDocsSidebar();
   }
 
   #findIndexForActiveCategory() {

--- a/spec/system/doc_category_sidebar_spec.rb
+++ b/spec/system/doc_category_sidebar_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe "Doc Category Sidebar", system: true do
           :user_chat_channel_membership,
           user: admin,
           chat_channel: Fabricate(:chat_channel),
-          )
+        )
       admin.upsert_custom_fields(::Chat::LAST_CHAT_CHANNEL_ID => membership.chat_channel.id)
       chat_page.prefers_full_page
 


### PR DESCRIPTION
- Prevent the main sidebar panel flashing before loading the docs sidebar when loading a route for the first time
- Add a test for the interaction with the chat plugin to verify if the docs sidebar is still displayed after opening/closing the drawer