### PR TITLE
FIX: Parse text from non-TEXT elements before colon correctly

### DIFF
--- a/lib/doc_categories/doc_index_topic_parser.rb
+++ b/lib/doc_categories/doc_index_topic_parser.rb
@@ -50,14 +50,14 @@ class ::DocCategories::DocIndexTopicParser
     node.children.each { |child| add_link(child) if list_item?(child) }
   end
 
-  def add_link(node)
-    anchor = node.at_css("a")
+  def add_link(item_node)
+    nodes = item_node.children
+    anchor = nodes.reverse.find { |child| child.name == "a" }
     return unless anchor
 
-    if node.children.first.text?
-      title = node.children.first.text.strip
-
-      title.chop! if title.end_with?(":")
+    title = nodes.first(nodes.index(anchor)).map(&:text).join.strip
+    if title.present? && title.end_with?(":")
+      title.chop!
     else
       title = anchor.text.strip
     end

--- a/spec/lib/doc_index_topic_parser_spec.rb
+++ b/spec/lib/doc_index_topic_parser_spec.rb
@@ -186,6 +186,27 @@ RSpec.describe ::DocCategories::DocIndexTopicParser do
       expect(links[0]).to eq({ text: "Test", href: "/test" })
     end
 
+    it "will use the last anchor as the source of the link and extract the text from the elements before" do
+      cooked_text = <<-HTML
+      <ul>
+        <li>Another <a href="/test">test</a>: <a href="/another-test">This is another test</a></li>
+      </ul>
+      HTML
+
+      p = described_class.new(cooked_text)
+      sections = p.sections
+
+      expect(sections.size).to eq(1)
+
+      root_section = sections.first
+      expect(root_section[:text]).to be_nil
+
+      links = root_section[:links]
+      expect(links.size).to eq(1)
+
+      expect(links[0]).to eq({ text: "Another test", href: "/another-test" })
+    end
+
     it "it will use the anchor inner text as the text in case another one is not provided" do
       cooked_text = <<-HTML
       <ul>


### PR DESCRIPTION
Fix for the issue reported on https://meta.discourse.org/t/autolinking-and-doc-sidebar/330937