### PR TITLE
FIX: no doc sidebar in admin

### DIFF
--- a/assets/javascripts/discourse/services/doc-category-sidebar.js
+++ b/assets/javascripts/discourse/services/doc-category-sidebar.js
@@ -1,6 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import Service, { inject as service } from "@ember/service";
-import { MAIN_PANEL } from "discourse/lib/sidebar/panels";
+import { ADMIN_PANEL, MAIN_PANEL } from "discourse/lib/sidebar/panels";
 import { deepEqual } from "discourse-common/lib/object";
 import { bind } from "discourse-common/utils/decorators";
 
@@ -31,6 +31,10 @@ export default class DocCategorySidebarService extends Service {
   }
 
   get activeCategory() {
+    if (this.sidebarState.currentPanel?.key === ADMIN_PANEL) {
+      return;
+    }
+
     return (
       this.router.currentRoute?.attributes?.category ||
       this.router.currentRoute?.parent?.attributes?.category

--- a/spec/system/doc_category_sidebar_spec.rb
+++ b/spec/system/doc_category_sidebar_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe "Doc Category Sidebar", system: true do
     Fabricate(:post, topic: t)
     t
   end
+  fab!(:permalink) do
+    Fabricate(
+      :permalink,
+      permalink_type_value: documentation_category.id,
+      permalink_type: "category",
+    )
+  end
   fab!(:index_topic) do
     t = Fabricate(:topic, category: documentation_category)
 
@@ -142,6 +149,19 @@ RSpec.describe "Doc Category Sidebar", system: true do
 
       expect(sidebar).to be_visible
       expect(sidebar).to have_section(docs_section_name("Subcategory Index"))
+    end
+  end
+
+  context "when admin sidebar" do
+    fab!(:admin)
+
+    before { sign_in(admin) }
+
+    it "should never display the docs sidebar" do
+      visit("/admin/customize/permalinks/#{permalink.id}")
+      expect(sidebar).to be_visible
+      expect(sidebar).to have_no_section(docs_section_name("General Usage"))
+      expect(page).to have_css(".admin-panel")
     end
   end
 


### PR DESCRIPTION
Currently, the documentation sidebar is displayed when the model attributes contain the documented category.

It can incorrectly display the documentation sidebar in the admin panel. For example, when editing  `permalink`, which redirects to the documentation category.

<img width="1422" alt="Screenshot 2024-11-18 at 1 14 15 PM" src="https://github.com/user-attachments/assets/ba0c971c-f78e-4367-ba1f-efb5ab53f9f2">
