### PR TITLE
FIX: permalink spec

### DIFF
--- a/spec/system/doc_category_sidebar_spec.rb
+++ b/spec/system/doc_category_sidebar_spec.rb
@@ -32,13 +32,7 @@ RSpec.describe "Doc Category Sidebar", system: true do
     Fabricate(:post, topic: t)
     t
   end
-  fab!(:permalink) do
-    Fabricate(
-      :permalink,
-      permalink_type_value: documentation_category.id,
-      permalink_type: "category",
-    )
-  end
+  fab!(:permalink) { Fabricate(:permalink, category_id: documentation_category.id) }
   fab!(:index_topic) do
     t = Fabricate(:topic, category: documentation_category)
 


### PR DESCRIPTION
In this PR, Permalinks logic was moved back to the controller, and `permalink_type` is not accepted anymore - https://github.com/discourse/discourse/pull/29895

Therefore, the spec should be adjusted as well.