### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+< 3.4.0.beta2-dev: 96418d107d3e90fcd5a7db02fe52e955dc972a5b

--- a/assets/javascripts/discourse/components/doc-category-settings.gjs
+++ b/assets/javascripts/discourse/components/doc-category-settings.gjs
@@ -108,7 +108,7 @@ export default class DocCategorySettings extends Component {
         />
         {{#if this.shouldDisplayErrorMessage}}
           <div class="validation-error">
-            {{dIcon "times"}}
+            {{dIcon "xmark"}}
             {{this.errorMessage}}
           </div>
         {{/if}}


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.