### PR TITLE
DEV: bring back filter spec

### DIFF
--- a/spec/system/doc_category_sidebar_spec.rb
+++ b/spec/system/doc_category_sidebar_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe "Doc Category Sidebar", system: true do
   end
 
   let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
+  let(:filter) { PageObjects::Components::Filter.new }
 
   def docs_section_name(title)
     "discourse-docs-sidebar__#{Slug.for(title)}"
@@ -173,6 +174,53 @@ RSpec.describe "Doc Category Sidebar", system: true do
       chat_page.minimize_full_page
       expect(chat_page).to have_drawer
       expect_docs_sidebar_to_be_correct
+    end
+  end
+
+  context "when filtering" do
+    it "suggests filtering the content when there are no results" do
+      SiteSetting.max_category_nesting = 3
+      documentation_subsubcategory =
+        Fabricate(:category_with_definition, parent_category_id: documentation_subcategory.id)
+
+      visit("/c/#{documentation_category.slug}/#{documentation_category.id}")
+
+      filter.filter("missing")
+      expect(page).to have_no_css(".sidebar-section-link-content-text")
+      expect(page).to have_css(".sidebar-no-results")
+
+      no_results_description = page.find(".sidebar-no-results__description")
+      expect(no_results_description.text).to eq(
+        "We couldn’t find anything matching ‘missing’.\nDo you want to perform a search on this category or a site wide search instead?",
+      )
+
+      suggested_category_search = page.find(".docs-sidebar-suggested-category-search")
+      expect(suggested_category_search[:href]).to end_with(
+        "/search?q=missing%20%23#{documentation_category.slug}",
+      )
+
+      site_wide_search = page.find(".docs-sidebar-suggested-site-search")
+      expect(site_wide_search[:href]).to end_with("/search?q=missing")
+
+      # for subcategories
+      visit(
+        "/c/#{documentation_category.slug}/#{documentation_subcategory.slug}/#{documentation_subcategory.id}",
+      )
+      filter.filter("missing")
+
+      suggested_category_search = page.find(".docs-sidebar-suggested-category-search")
+      expect(suggested_category_search[:href]).to end_with(
+        "/search?q=missing%20%23#{documentation_category.slug}%3A#{documentation_subcategory.slug}",
+      )
+
+      # for 3 levels deep
+      visit("/c/#{documentation_subsubcategory.id}")
+      filter.filter("missing")
+
+      suggested_category_search = page.find(".docs-sidebar-suggested-category-search")
+      expect(suggested_category_search[:href]).to end_with(
+        "/search?q=missing%20category%3A#{documentation_subsubcategory.id}",
+      )
     end
   end
 


### PR DESCRIPTION
Spec was removed here https://github.com/discourse/discourse-doc-categories/pull/38

Because we brought back filter functionality, it is working again - https://github.com/discourse/discourse/pull/32837

Meta: https://meta.discourse.org/t/discourse-doc-categories/322376/123