### PR TITLE
DEV: Fix category customn field preloading

### DIFF
--- a/lib/doc_categories/docs_legacy_constraint.rb
+++ b/lib/doc_categories/docs_legacy_constraint.rb
@@ -2,6 +2,6 @@
 
 class ::DocCategories::DocsLegacyConstraint
   def matches?(_request)
-    ::DocCategories.legacyMode?
+    ::DocCategories.legacy_mode?
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -21,7 +21,7 @@ module ::DocCategories
 
   CATEGORY_INDEX_TOPIC = "doc_category_index_topic"
 
-  def self.legacyMode?
+  def self.legacy_mode?
     # disable the compatibility mode if the docs plugin is enabled
     return false if defined?(::Docs) && SiteSetting.docs_enabled
     SiteSetting.doc_categories_docs_legacy_enabled
@@ -56,13 +56,14 @@ require_relative "lib/doc_categories/engine"
 
 after_initialize do
   register_category_custom_field_type(DocCategories::CATEGORY_INDEX_TOPIC, :integer)
-  Site.preloaded_category_custom_fields << DocCategories::CATEGORY_INDEX_TOPIC
+
+  reloadable_patch { Site.preloaded_category_custom_fields << DocCategories::CATEGORY_INDEX_TOPIC }
 
   # legacy docs
   add_to_serializer(
     :site,
     :docs_legacy_path,
-    include_condition: -> { DocCategories.legacyMode? },
+    include_condition: -> { DocCategories.legacy_mode? },
   ) { GlobalSetting.docs_path }
 
   DocCategories::Initializers.apply(self)


### PR DESCRIPTION
Move the line `Site.preloaded_category_custom_fields <<`
into `reloadable_patch` like we do in other plugins to avoid
the `NotPreloadedError`
