### PR TITLE
DEV: Add tables and models for documentation sidebar indexes, sections, and links

### DIFF
--- a/app/models/doc_categories/index.rb
+++ b/app/models/doc_categories/index.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DocCategories
+  class Index < ActiveRecord::Base
+    self.table_name = "doc_categories_indexes"
+
+    belongs_to :category, class_name: "::Category"
+    belongs_to :index_topic, class_name: "::Topic"
+
+    has_many :sidebar_sections,
+             -> { order(:position) },
+             class_name: "DocCategories::SidebarSection",
+             foreign_key: :doc_categories_index_id,
+             inverse_of: :index,
+             dependent: :destroy
+
+    validates :category_id, presence: true, uniqueness: true
+    validates :index_topic_id, presence: true, uniqueness: true
+
+    validate :index_topic_matches_category
+
+    private
+
+    def index_topic_matches_category
+      return if index_topic_id.blank? || category_id.blank?
+      return if index_topic&.category_id == category_id
+
+      errors.add(:index_topic_id, "must belong to the same category")
+    end
+  end
+end

--- a/app/models/doc_categories/sidebar_link.rb
+++ b/app/models/doc_categories/sidebar_link.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module DocCategories
+  class SidebarLink < ActiveRecord::Base
+    self.table_name = "doc_categories_sidebar_links"
+
+    belongs_to :sidebar_section,
+               class_name: "DocCategories::SidebarSection",
+               foreign_key: :doc_categories_sidebar_section_id,
+               inverse_of: :sidebar_links
+
+    belongs_to :topic, optional: true
+
+    validates :doc_categories_sidebar_section_id, presence: true
+    validates :position, presence: true, uniqueness: { scope: :doc_categories_sidebar_section_id }
+    validates :title, length: { maximum: 255 }
+    validates :href, length: { maximum: 2000 }
+    validate :target_present
+    validate :topic_not_deleted
+
+    private
+
+    def target_present
+      return if topic_id.present? || href.present?
+
+      errors.add(:base, "must include either a topic or href")
+    end
+
+    def topic_not_deleted
+      return if topic.nil?
+
+      return unless topic.deleted_at.present? || topic.deleted_by_id.present?
+
+      errors.add(:topic_id, "cannot reference a deleted topic")
+    end
+  end
+end

--- a/app/models/doc_categories/sidebar_section.rb
+++ b/app/models/doc_categories/sidebar_section.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module DocCategories
+  class SidebarSection < ActiveRecord::Base
+    self.table_name = "doc_categories_sidebar_sections"
+
+    belongs_to :index,
+               class_name: "DocCategories::Index",
+               foreign_key: :doc_categories_index_id,
+               inverse_of: :sidebar_sections
+
+    has_many :sidebar_links,
+             -> { order(:position) },
+             class_name: "DocCategories::SidebarLink",
+             foreign_key: :doc_categories_sidebar_section_id,
+             inverse_of: :sidebar_section,
+             dependent: :destroy
+
+    validates :doc_categories_index_id, presence: true
+    validates :position, presence: true, uniqueness: { scope: :doc_categories_index_id }
+    validates :title, length: { maximum: 255 }, allow_blank: true
+  end
+end

--- a/db/migrate/20250918020855_create_doc_categories_tables.rb
+++ b/db/migrate/20250918020855_create_doc_categories_tables.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class CreateDocCategoriesTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :doc_categories_indexes do |t|
+      t.bigint :category_id, null: false
+      t.bigint :index_topic_id, null: false
+      t.timestamps
+    end
+
+    add_index :doc_categories_indexes,
+              :category_id,
+              unique: true,
+              name: :idx_doc_categories_indexes_on_category_id
+    add_index :doc_categories_indexes,
+              :index_topic_id,
+              unique: true,
+              name: :idx_doc_categories_indexes_on_index_topic_id
+
+    create_table :doc_categories_sidebar_sections do |t|
+      t.bigint :doc_categories_index_id, null: false
+      t.string :title
+      t.integer :position, null: false
+      t.timestamps
+    end
+
+    add_index :doc_categories_sidebar_sections,
+              [:doc_categories_index_id, :position],
+              unique: true,
+              name: :idx_doc_categories_sections_on_index_id_and_position
+
+    create_table :doc_categories_sidebar_links do |t|
+      t.bigint :doc_categories_sidebar_section_id, null: false
+      t.string :title
+      t.text :href
+      t.integer :position, null: false
+      t.bigint :topic_id
+      t.timestamps
+    end
+
+    add_index :doc_categories_sidebar_links,
+              [:doc_categories_sidebar_section_id, :position],
+              unique: true,
+              name: :idx_doc_categories_links_on_section_id_and_position
+    add_index :doc_categories_sidebar_links, :topic_id
+  end
+end

--- a/spec/models/doc_categories/index_spec.rb
+++ b/spec/models/doc_categories/index_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+describe DocCategories::Index do
+  fab!(:category) { Fabricate(:category_with_definition) }
+  fab!(:index_topic) do
+    Fabricate(:topic, category: category).tap { |topic| Fabricate(:post, topic: topic) }
+  end
+  fab!(:alternate_topic) do
+    Fabricate(:topic, category: category).tap { |topic| Fabricate(:post, topic: topic) }
+  end
+
+  subject(:doc_index) { described_class.create!(category: category, index_topic: index_topic) }
+
+  it "requires the index topic to match the category" do
+    mismatched_category = Fabricate(:category_with_definition)
+    mismatched_topic =
+      Fabricate(:topic, category: mismatched_category).tap { |topic| Fabricate(:post, topic: topic) }
+
+    record = described_class.new(category: category, index_topic: mismatched_topic)
+
+    expect(record).not_to be_valid
+    expect(record.errors[:index_topic_id]).to include("must belong to the same category")
+  end
+
+  it "enforces a unique category" do
+    doc_index
+
+    duplicate = described_class.new(category: category, index_topic: alternate_topic)
+
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:category_id]).to be_present
+  end
+
+  it "enforces a unique index topic" do
+    doc_index
+
+    other_category = Fabricate(:category_with_definition)
+
+    duplicate = described_class.new(category: other_category, index_topic: index_topic)
+
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:index_topic_id]).to be_present
+  end
+
+  it "orders sidebar sections by their position" do
+    later = doc_index.sidebar_sections.create!(position: 2, title: "Later")
+    earlier = doc_index.sidebar_sections.create!(position: 1, title: "Earlier")
+
+    expect(doc_index.reload.sidebar_sections.map(&:id)).to eq([earlier.id, later.id])
+  end
+end

--- a/spec/models/doc_categories/sidebar_link_spec.rb
+++ b/spec/models/doc_categories/sidebar_link_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+describe DocCategories::SidebarLink do
+  fab!(:category) { Fabricate(:category_with_definition) }
+  fab!(:index_topic) do
+    Fabricate(:topic, category: category).tap { |topic| Fabricate(:post, topic: topic) }
+  end
+
+  let!(:doc_index) { DocCategories::Index.create!(category: category, index_topic: index_topic) }
+  let!(:section) { DocCategories::SidebarSection.create!(index: doc_index, position: 1, title: "Links") }
+
+  it "enforces unique positioning within a section" do
+    described_class.create!(sidebar_section: section, position: 1, title: "Docs", href: "/docs")
+
+    duplicate = described_class.new(sidebar_section: section, position: 1)
+
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:position]).to include("has already been taken")
+  end
+
+  it "requires a topic or href" do
+    link = described_class.new(sidebar_section: section, position: 1, title: "Docs")
+
+    expect(link).not_to be_valid
+    expect(link.errors[:base]).to include("must include either a topic or href")
+  end
+
+  it "accepts linking directly to a topic" do
+    linked_topic = Fabricate(:topic, category: category).tap { |topic| Fabricate(:post, topic: topic) }
+
+    link =
+      described_class.create!(
+        sidebar_section: section,
+        position: 1,
+        title: linked_topic.title,
+        topic: linked_topic,
+      )
+
+    expect(link.reload.topic).to eq(linked_topic)
+    expect(link.href).to be_nil
+  end
+
+  it "rejects deleted topics" do
+    linked_topic = Fabricate(:topic, category: category).tap { |topic| Fabricate(:post, topic: topic) }
+    linked_topic.trash!
+
+    link =
+      described_class.new(
+        sidebar_section: section,
+        position: 1,
+        topic: linked_topic,
+      )
+
+    expect(link).not_to be_valid
+    expect(link.errors[:topic_id]).to include("cannot reference a deleted topic")
+  end
+
+  it "rejects href values longer than the limit" do
+    link =
+      described_class.new(
+        sidebar_section: section,
+        position: 1,
+        href: "https://" + "a" * 1992,
+      )
+
+    expect(link).to be_valid
+
+    link.href = "https://" + "a" * 1993
+
+    expect(link).not_to be_valid
+    expect(link.errors[:href]).to include("is too long (maximum is 2000 characters)")
+  end
+end

--- a/spec/models/doc_categories/sidebar_section_spec.rb
+++ b/spec/models/doc_categories/sidebar_section_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+describe DocCategories::SidebarSection do
+  fab!(:category) { Fabricate(:category_with_definition) }
+  fab!(:index_topic) do
+    Fabricate(:topic, category: category).tap { |topic| Fabricate(:post, topic: topic) }
+  end
+
+  let!(:doc_index) { DocCategories::Index.create!(category: category, index_topic: index_topic) }
+
+  it "enforces unique positioning within an index" do
+    described_class.create!(index: doc_index, position: 1, title: "General")
+
+    duplicate = described_class.new(index: doc_index, position: 1)
+
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:position]).to include("has already been taken")
+  end
+
+  it "allows the same position on different indexes" do
+    described_class.create!(index: doc_index, position: 1, title: "General")
+
+    other_category = Fabricate(:category_with_definition)
+    other_topic =
+      Fabricate(:topic, category: other_category).tap { |topic| Fabricate(:post, topic: topic) }
+    other_index = DocCategories::Index.create!(category: other_category, index_topic: other_topic)
+
+    duplicate_position = described_class.new(index: other_index, position: 1)
+
+    expect(duplicate_position).to be_valid
+  end
+
+  it "orders sidebar links by their position" do
+    section = described_class.create!(index: doc_index, position: 1, title: "Links")
+
+    later = section.sidebar_links.create!(position: 3, title: "Later", href: "/later")
+    earlier = section.sidebar_links.create!(position: 1, title: "Earlier", href: "/earlier")
+    middle = section.sidebar_links.create!(position: 2, title: "Middle", href: "/middle")
+
+    expect(section.reload.sidebar_links.map(&:id)).to eq([earlier.id, middle.id, later.id])
+  end
+
+  it "cleans up sidebar links when destroyed" do
+    section = described_class.create!(index: doc_index, position: 1, title: "Links")
+    link = section.sidebar_links.create!(position: 1, title: "Earlier", href: "/earlier")
+
+    section.destroy!
+
+    expect { link.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end


### PR DESCRIPTION
We want to move docs from live parsing of the index to load from tables instead. This PR creates the tables with appropriate validations.

Part 1 of many.

Internal: t/147997/27