### PR TITLE
DEV: Move plugin to be supported by tables

### DIFF
--- a/app/services/doc_categories/category_index_manager.rb
+++ b/app/services/doc_categories/category_index_manager.rb
@@ -12,7 +12,6 @@ module DocCategories
       if topic_id.nil?
         if (index = DocCategories::Index.find_by(category_id: category.id))
           index.destroy!
-          reset_category_index_association
           category.reload
           enqueue_refresh
           return true
@@ -29,7 +28,6 @@ module DocCategories
 
       index.index_topic = topic
       index.save!
-      assign_category_index_association(index)
       enqueue_refresh
 
       true
@@ -57,22 +55,6 @@ module DocCategories
 
     def enqueue_refresh
       ::Jobs.enqueue(:doc_categories_refresh_index, category_id: category.id)
-    end
-
-    def reset_category_index_association
-      association = category.association(:doc_categories_index)
-      return unless association
-
-      association.target = nil
-      association.loaded!
-    end
-
-    def assign_category_index_association(index)
-      association = category.association(:doc_categories_index)
-      return unless association
-
-      association.target = index
-      association.loaded!
     end
   end
 end

--- a/app/services/doc_categories/index_structure_refresher.rb
+++ b/app/services/doc_categories/index_structure_refresher.rb
@@ -94,7 +94,7 @@ module DocCategories
       category = ::Category.find_by(id: category_id)
       return unless category
 
-      ::Site.clear_cache
+      Site.clear_cache
       category.publish_category
     end
   end

--- a/assets/javascripts/discourse/components/doc-category-settings.gjs
+++ b/assets/javascripts/discourse/components/doc-category-settings.gjs
@@ -12,8 +12,7 @@ export default class DocCategorySettings extends Component {
     return context.siteSettings.doc_categories_enabled;
   }
 
-  @tracked indexTopicId =
-    this.args.outletArgs.category.doc_index_topic_id;
+  @tracked indexTopicId = this.args.outletArgs.category.doc_index_topic_id;
   @tracked indexTopic;
   @tracked loadingIndexTopic = !!this.indexTopicId;
 

--- a/assets/javascripts/discourse/components/doc-category-settings.gjs
+++ b/assets/javascripts/discourse/components/doc-category-settings.gjs
@@ -14,7 +14,7 @@ export default class DocCategorySettings extends Component {
 
   @tracked
   indexTopicId =
-    this.args.outletArgs.category.custom_fields.doc_category_index_topic;
+    this.args.outletArgs.category.doc_index_topic_id;
   @tracked indexTopic;
   @tracked loadingIndexTopic = !!this.indexTopicId;
 
@@ -88,7 +88,7 @@ export default class DocCategorySettings extends Component {
   onChangeIndexTopic(topicId, topic) {
     this.indexTopic = topic;
     this.indexTopicId = topicId;
-    this.category.custom_fields.doc_category_index_topic = topicId;
+    this.category.doc_index_topic_id = topicId;
   }
 
   <template>

--- a/assets/javascripts/discourse/components/doc-category-settings.gjs
+++ b/assets/javascripts/discourse/components/doc-category-settings.gjs
@@ -12,8 +12,7 @@ export default class DocCategorySettings extends Component {
     return context.siteSettings.doc_categories_enabled;
   }
 
-  @tracked
-  indexTopicId =
+  @tracked indexTopicId =
     this.args.outletArgs.category.doc_index_topic_id;
   @tracked indexTopic;
   @tracked loadingIndexTopic = !!this.indexTopicId;

--- a/assets/javascripts/discourse/initializers/doc-categories.gjs
+++ b/assets/javascripts/discourse/initializers/doc-categories.gjs
@@ -8,6 +8,7 @@ export default {
     container.lookup("service:doc-category-sidebar");
 
     withPluginApi("1.34.0", (api) => {
+      api.registerCategorySaveProperty("doc_index_topic_id");
       api.renderInOutlet("category-custom-settings", DocCategorySettings);
       api.addSidebarPanel(DocCategorySidebarPanel);
     });

--- a/db/migrate/20250918021916_backfill_doc_categories_indexes.rb
+++ b/db/migrate/20250918021916_backfill_doc_categories_indexes.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class BackfillDocCategoriesIndexes < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      INSERT INTO doc_categories_indexes (category_id, index_topic_id, created_at, updated_at)
+      SELECT ccf.category_id, ccf.value::bigint, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      FROM category_custom_fields ccf
+      JOIN topics t ON t.id = ccf.value::bigint
+      WHERE ccf.name = 'doc_category_index_topic'
+        AND t.category_id = ccf.category_id
+        AND NOT EXISTS (
+          SELECT 1
+          FROM doc_categories_indexes existing
+          WHERE existing.category_id = ccf.category_id
+        )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/doc_categories/initializers/add_category_extensions.rb
+++ b/lib/doc_categories/initializers/add_category_extensions.rb
@@ -24,7 +24,7 @@ module ::DocCategories
         plugin.add_to_class(:category, :doc_index_topic_id) { doc_categories_index&.index_topic_id }
 
         plugin.add_to_serializer(:basic_category, :doc_index_topic_id) do
-          object.doc_categories_index&.index_topic_id
+          object&.doc_categories_index&.index_topic_id
         end
 
         plugin.register_category_update_param_with_callback(

--- a/lib/doc_categories/initializers/add_category_extensions.rb
+++ b/lib/doc_categories/initializers/add_category_extensions.rb
@@ -16,17 +16,20 @@ module ::DocCategories
         Category.prepend CategoryExtension
 
         plugin.add_class_method(:category, :doc_category_ids) do
-          CategoryCustomField
-            .where(name: DocCategories::CATEGORY_INDEX_TOPIC)
-            .where.not(value: nil)
-            .pluck(:category_id)
+          DocCategories::Index.pluck(:category_id)
         end
 
-        plugin.add_to_class(:category, :doc_category?) { doc_index_topic_id.present? }
+        plugin.add_to_class(:category, :doc_category?) { doc_categories_index.present? }
 
-        plugin.add_to_class(:category, :doc_index_topic_id) do
-          custom_fields[DocCategories::CATEGORY_INDEX_TOPIC]
+        plugin.add_to_class(:category, :doc_index_topic_id) { doc_categories_index&.index_topic_id }
+
+        plugin.add_to_serializer(:basic_category, :doc_index_topic_id) do
+          object.doc_categories_index&.index_topic_id
         end
+
+        plugin.register_category_update_param_with_callback(
+          :doc_index_topic_id,
+        ) { |category, value| DocCategories::CategoryIndexManager.new(category).assign!(value) }
       end
     end
   end

--- a/lib/doc_categories/initializers/handle_post_changes.rb
+++ b/lib/doc_categories/initializers/handle_post_changes.rb
@@ -4,20 +4,16 @@ module ::DocCategories
   module Initializers
     class HandlePostChanges < Initializer
       def apply
-        # reset cache when
-        # - index topic post cooked changes
-        # - the category of the topic changes (might change to undefined)
         plugin.on(:post_edited) do |post, _, revisor|
           topic = post.topic
           category = topic&.category
 
           if doc_index_topic_post_cooked_changed?(topic, category, post, revisor)
-            reset_docs_categories([category].compact)
+            enqueue_refresh(category.id)
             next
           end
 
-          categories = category_change_involves_doc_category?(topic, category, revisor)
-          reset_docs_categories(categories) if categories.present?
+          handle_category_change(topic, category, revisor)
         end
       end
 
@@ -28,39 +24,28 @@ module ::DocCategories
           doc_index_topic?(topic, category)
       end
 
-      def category_change_involves_doc_category?(topic, current_category, revisor)
-        return [] unless revisor.topic_diff.has_key?("category_id")
+      def handle_category_change(topic, current_category, revisor)
+        return if !revisor.topic_diff.has_key?("category_id")
 
-        previous_id, current_id = revisor.topic_diff["category_id"]
+        prev_id, curr_id = revisor.topic_diff["category_id"]
 
-        categories = []
+        # topic is moved into a doc category which it is the index for
+        if curr_id == current_category.id && doc_index_topic?(topic, current_category)
+          enqueue_refresh(curr_id)
+          return
+        end
 
-        # if topic was index topic but moved out of the category
-        previous_category = category_for_id(previous_id, current_category)
-        categories << previous_category if doc_index_topic?(topic, previous_category)
-
-        # if topic moved into a category where it is the index topic
-        current_category = category_for_id(current_id, current_category)
-        categories << current_category if doc_index_topic?(topic, current_category)
-
-        categories.compact.uniq
-      end
-
-      def category_for_id(category_id, current_category)
-        return nil if category_id.blank?
-        return current_category if current_category&.id == category_id
-
-        Category.find_by(id: category_id)
+        # topic is moved out of a doc category which it is the index for
+        prev_category = Category.find_by(id: prev_id)
+        enqueue_refresh(prev_id) if prev_category && doc_index_topic?(topic, prev_category)
       end
 
       def doc_index_topic?(topic, category)
         category&.doc_index_topic_id == topic&.id
       end
 
-      def reset_docs_categories(categories)
-        # since the index structure is serialized into the category data, we need to invalidate the site cache when the first post of an index topic is updated
-        Site.clear_cache
-        categories.each { |cat| cat.publish_category }
+      def enqueue_refresh(category_id)
+        ::Jobs.enqueue(:doc_categories_refresh_index, category_id: category_id)
       end
     end
   end

--- a/lib/doc_categories/initializers/handle_topic_changes.rb
+++ b/lib/doc_categories/initializers/handle_topic_changes.rb
@@ -2,22 +2,46 @@
 
 module ::DocCategories
   module Initializers
-    # since the index structure is serialized into the category data, we need to invalidate the site cache when
-    # an index topic changes category or is deleted
-
     class HandleTopicChanges < Initializer
       def apply
         plugin.add_class_method(:topic, :clear_doc_categories_cache) { Site.clear_cache }
 
-        plugin.on(:topic_trashed) do |topic|
-          Topic.clear_doc_categories_cache if topic.category&.doc_index_topic_id == topic.id
-          topic.category&.publish_category
-        end
+        plugin.on(:topic_trashed) { |topic| handle_topic_trashed(topic) }
 
-        plugin.on(:topic_recovered) do |topic|
-          Topic.clear_doc_categories_cache if topic.category&.doc_index_topic_id == topic.id
-          topic.category&.publish_category
+        plugin.on(:topic_recovered) { |topic| handle_topic_recovered(topic) }
+      end
+
+      private
+
+      def handle_topic_trashed(topic)
+        index = DocCategories::Index.find_by(index_topic_id: topic.id)
+        return if !index
+
+        category = index.category
+        return if !category
+
+        DocCategories::CategoryIndexManager.new(category).assign!(nil)
+      end
+
+      def handle_topic_recovered(topic)
+        category = topic.category
+        return if !category
+
+        existing_index = DocCategories::Index.find_by(category_id: category.id)
+
+        return if existing_index.present? && existing_index.index_topic_id != topic.id
+
+        if existing_index&.index_topic_id == topic.id
+          enqueue_refresh(category.id)
+        elsif existing_index.nil?
+          DocCategories::CategoryIndexManager.new(category).assign!(topic.id)
+        else
+          return
         end
+      end
+
+      def enqueue_refresh(category_id)
+        ::Jobs.enqueue(:doc_categories_refresh_index, category_id: category_id)
       end
     end
   end

--- a/lib/doc_categories/initializers/handle_topic_changes.rb
+++ b/lib/doc_categories/initializers/handle_topic_changes.rb
@@ -35,8 +35,6 @@ module ::DocCategories
           enqueue_refresh(category.id)
         elsif existing_index.nil?
           DocCategories::CategoryIndexManager.new(category).assign!(topic.id)
-        else
-          return
         end
       end
 

--- a/lib/doc_categories/initializers/preload_doc_categories.rb
+++ b/lib/doc_categories/initializers/preload_doc_categories.rb
@@ -5,7 +5,9 @@ module ::DocCategories
     class PreloadDocCategories < Initializer
       def apply
         plugin.register_modifier(:site_all_categories_cache_query) do |query|
-          if SiteSetting.doc_categories_enabled
+          # sometimes the association is not loaded yet
+          if SiteSetting.doc_categories_enabled &&
+               Category.reflect_on_association(:doc_categories_index)
             query =
               query.includes(
                 doc_categories_index: [:index_topic, { sidebar_sections: :sidebar_links }],

--- a/lib/doc_categories/initializers/preload_doc_categories.rb
+++ b/lib/doc_categories/initializers/preload_doc_categories.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ::DocCategories
+  module Initializers
+    class PreloadDocCategories < Initializer
+      def apply
+        plugin.register_modifier(:site_all_categories_cache_query) do |query|
+          if SiteSetting.doc_categories_enabled
+            query =
+              query.includes(
+                doc_categories_index: [:index_topic, { sidebar_sections: :sidebar_links }],
+              )
+          end
+
+          query
+        end
+      end
+    end
+  end
+end

--- a/lib/doc_categories/initializers/serialize_index_structure.rb
+++ b/lib/doc_categories/initializers/serialize_index_structure.rb
@@ -9,7 +9,7 @@ module ::DocCategories
           :basic_category,
           :doc_category_index,
           include_condition: -> do
-            index = object.doc_categories_index
+            index = object&.doc_categories_index
             next false if index.blank?
 
             index_topic = index.index_topic

--- a/lib/doc_categories/initializers/serialize_index_structure.rb
+++ b/lib/doc_categories/initializers/serialize_index_structure.rb
@@ -9,10 +9,10 @@ module ::DocCategories
           :basic_category,
           :doc_category_index,
           include_condition: -> do
-            index_topic_id = object.custom_fields[::DocCategories::CATEGORY_INDEX_TOPIC]
-            next false if index_topic_id.blank?
+            index = object.doc_categories_index
+            next false if index.blank?
 
-            index_topic = Topic.find_by(id: index_topic_id)
+            index_topic = index.index_topic
             next false if index_topic.blank?
 
             # ideally we should check if the current user has access to the topic above which would allow securely using
@@ -26,7 +26,7 @@ module ::DocCategories
             first_post = index_topic.first_post
             next false if first_post.blank?
 
-            @doc_category_index = DocCategories::DocIndexTopicParser.new(first_post.cooked).sections
+            @doc_category_index = index.sidebar_structure
             @doc_category_index.present?
           end,
         ) { @doc_category_index.as_json }

--- a/lib/tasks/doc_categories.rake
+++ b/lib/tasks/doc_categories.rake
@@ -9,14 +9,9 @@ namespace :doc_categories do
       .includes(:category)
       .find_each do |index|
         category = index.category
-
-        if category.blank?
-          puts "Skipping index ##{index.id} because category #{index.category_id} is missing."
-          next
-        end
-
         puts "Processing category ##{category.id} (#{category.name})"
         DocCategories::IndexStructureRefresher.new(category.id).refresh!
+        puts " ⮑  Created #{index.sidebar_sections.count} sections and #{index.sidebar_sections.sum { |section| section.sidebar_links.count }} links"
       rescue => e
         puts "Failed to process category ##{category.id}: #{e.message}"
       end

--- a/lib/tasks/doc_categories.rake
+++ b/lib/tasks/doc_categories.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :doc_categories do
+  desc "Parse active doc index topics and populate sidebar sections/links"
+  task build_sidebar: :environment do
+    next if !SiteSetting.doc_categories_enabled
+
+    DocCategories::Index
+      .includes(:category)
+      .find_each do |index|
+        category = index.category
+
+        if category.blank?
+          puts "Skipping index ##{index.id} because category #{index.category_id} is missing."
+          next
+        end
+
+        puts "Processing category ##{category.id} (#{category.name})"
+        DocCategories::IndexStructureRefresher.new(category.id).refresh!
+      rescue => e
+        puts "Failed to process category ##{category.id}: #{e.message}"
+      end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -19,8 +19,6 @@ register_svg_icon "far-file"
 module ::DocCategories
   PLUGIN_NAME = "discourse-doc-categories"
 
-  CATEGORY_INDEX_TOPIC = "doc_category_index_topic"
-
   def self.legacy_mode?
     # disable the compatibility mode if the docs plugin is enabled
     return false if defined?(::Docs) && SiteSetting.docs_enabled
@@ -55,10 +53,6 @@ end
 require_relative "lib/doc_categories/engine"
 
 after_initialize do
-  register_category_custom_field_type(DocCategories::CATEGORY_INDEX_TOPIC, :integer)
-
-  reloadable_patch { Site.preloaded_category_custom_fields << DocCategories::CATEGORY_INDEX_TOPIC }
-
   # legacy docs
   add_to_serializer(
     :site,

--- a/spec/lib/initializers/handle_post_changes_spec.rb
+++ b/spec/lib/initializers/handle_post_changes_spec.rb
@@ -4,19 +4,19 @@ describe DocCategories::Initializers::HandlePostChanges do
   fab!(:documentation_category) { Fabricate(:category_with_definition) }
   fab!(:other_category) { Fabricate(:category_with_definition) }
   fab!(:index_topic) do
-    Fabricate(:topic, category: documentation_category).tap do |topic|
-      Fabricate(:post, topic: topic)
-    end
+    Fabricate(:topic, category: documentation_category).tap { |topic| Fabricate(:post, topic:) }
   end
   fab!(:other_topic) do
-    Fabricate(:topic, category: other_category).tap { |topic| Fabricate(:post, topic: topic) }
+    Fabricate(:topic, category: other_category).tap { |topic| Fabricate(:post, topic:) }
+  end
+
+  let!(:doc_index) do
+    Fabricate(:doc_categories_index, category: documentation_category, index_topic:)
   end
 
   before do
     SiteSetting.doc_categories_enabled = true
-
-    documentation_category.custom_fields[DocCategories::CATEGORY_INDEX_TOPIC] = index_topic.id
-    documentation_category.save!
+    Jobs::DocCategoriesRefreshIndex.jobs.clear
   end
 
   def revise(post, topic = post.topic, **attributes)
@@ -24,37 +24,31 @@ describe DocCategories::Initializers::HandlePostChanges do
   end
 
   it "clears the cache and republishes the doc category when the index post cooked changes" do
-    Site.expects(:clear_cache).once
-
-    messages =
-      MessageBus.track_publish("/categories") do
-        revise(index_topic.first_post, raw: index_topic.first_post.raw + "\nUpdated")
-      end
-
-    category_ids = messages.flat_map { |message| message.data[:categories].map { |c| c[:id] } }
-
-    expect(category_ids).to include(documentation_category.id)
+    expect_enqueued_with(
+      job: :doc_categories_refresh_index,
+      args: {
+        category_id: documentation_category.id,
+      },
+    ) { revise(index_topic.first_post, raw: index_topic.first_post.raw + "\nUpdated") }
   end
 
   it "does not clear the cache for edits outside the doc index" do
-    Site.expects(:clear_cache).never
-
-    messages =
-      MessageBus.track_publish("/categories") { revise(other_topic.first_post, raw: "Changed") }
-
-    expect(messages).to be_empty
+    expect_not_enqueued_with(job: :doc_categories_refresh_index) do
+      revise(other_topic.first_post, raw: "Changed")
+    end
   end
 
-  it "clears the cache when the index topic leaves the doc category" do
-    Site.expects(:clear_cache).once
+  it "reassigns the index and refreshes the index's category when the index topic moves" do
+    expect_enqueued_with(
+      job: :doc_categories_refresh_index,
+      args: {
+        category_id: documentation_category.id,
+      },
+    ) { revise(index_topic.first_post, category_id: other_category.id) }
 
-    messages =
-      MessageBus.track_publish("/categories") do
-        revise(index_topic.first_post, category_id: other_category.id)
-      end
-
-    category_ids = messages.flat_map { |message| message.data[:categories].map { |c| c[:id] } }
-
-    expect(category_ids).to include(documentation_category.id)
+    expect(DocCategories::Index.exists?(category_id: documentation_category.id)).to eq(false)
+    expect(
+      DocCategories::Index.exists?(category_id: other_category.id, index_topic_id: index_topic.id),
+    ).to eq(true)
   end
 end

--- a/spec/lib/initializers/handle_post_changes_spec.rb
+++ b/spec/lib/initializers/handle_post_changes_spec.rb
@@ -38,17 +38,14 @@ describe DocCategories::Initializers::HandlePostChanges do
     end
   end
 
-  it "reassigns the index and refreshes the index's category when the index topic moves" do
-    expect_enqueued_with(
-      job: :doc_categories_refresh_index,
-      args: {
-        category_id: documentation_category.id,
-      },
-    ) { revise(index_topic.first_post, category_id: other_category.id) }
+  it "clears the index and refreshes the index's category when the index topic moves" do
+    Jobs.run_immediately!
+    revise(index_topic.first_post, category_id: other_category.id)
 
     expect(DocCategories::Index.exists?(category_id: documentation_category.id)).to eq(false)
+    # topic *should not* be the new category's index topic
     expect(
       DocCategories::Index.exists?(category_id: other_category.id, index_topic_id: index_topic.id),
-    ).to eq(true)
+    ).to eq(false)
   end
 end

--- a/spec/lib/reports/extraneous_items_report_spec.rb
+++ b/spec/lib/reports/extraneous_items_report_spec.rb
@@ -79,8 +79,9 @@ RSpec.describe ::DocCategories::Reports::ExtraneousItemsReport do
     before do
       SiteSetting.doc_categories_enabled = true
 
-      documentation_category.custom_fields[DocCategories::CATEGORY_INDEX_TOPIC] = index_topic.id
-      documentation_category.save!
+      Jobs.with_immediate_jobs do
+        DocCategories::CategoryIndexManager.new(documentation_category).assign!(index_topic.id)
+      end
     end
 
     it "returns the expected data when excluding topics from subcategories" do
@@ -200,17 +201,22 @@ RSpec.describe ::DocCategories::Reports::ExtraneousItemsReport do
           Fabricate(:post, topic: t, raw: index_topic.first_post.raw)
         end
 
-      other_category.custom_fields[
-        DocCategories::CATEGORY_INDEX_TOPIC
-      ] = other_category_index_topic.id
-      other_category.save!
+      Jobs.with_immediate_jobs do
+        DocCategories::CategoryIndexManager.new(other_category).assign!(
+          other_category_index_topic.id,
+        )
+      end
 
       generated_report = report(filters: { doc_category: -1 })
 
       expect(generated_report.filters[:doc_category]).to eq(-1)
       expect(generated_report.filters.has_key?(:include_topic_from_subcategories)).to eq(false)
 
-      expect(generated_report.data).to match_array(
+      grouped = generated_report.data.group_by { |row| row[:index_category_id] }
+
+      expect(grouped.keys).to contain_exactly(documentation_category.id, other_category.id)
+
+      expect(grouped[documentation_category.id]).to match_array(
         [
           {
             title: documentation_invisible_topic.title,
@@ -260,6 +266,11 @@ RSpec.describe ::DocCategories::Reports::ExtraneousItemsReport do
             index_category_name: documentation_category.name,
             index_category_url: "/c/#{documentation_category.id}",
           },
+        ],
+      )
+
+      expect(grouped[other_category.id]).to match_array(
+        [
           {
             title: documentation_topic.title,
             href: "/t/#{documentation_topic.slug}/#{documentation_topic.id}",

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -42,10 +42,11 @@ RSpec.describe Search do
       before { SiteSetting.doc_categories_enabled = true }
 
       it "includes only posts from the doc categories (including subcategories) in the results" do
-        documentation_category.custom_fields[
-          DocCategories::CATEGORY_INDEX_TOPIC
-        ] = documentation_category_topic.id
-        documentation_category.save!
+        Jobs.with_immediate_jobs do
+          DocCategories::CategoryIndexManager.new(documentation_category).assign!(
+            documentation_category_topic.id,
+          )
+        end
 
         results_with_advanced_search_trigger = Search.execute("looking in:docs").posts.map(&:id)
         results_without_advanced_search_trigger = Search.execute("looking").posts.map(&:id)

--- a/spec/serializers/basic_category_serializer_spec.rb
+++ b/spec/serializers/basic_category_serializer_spec.rb
@@ -8,6 +8,11 @@ describe BasicCategorySerializer do
   fab!(:documentation_subcategory) do
     Fabricate(:category_with_definition, parent_category_id: documentation_category.id)
   end
+  fab!(:empty_documentation_topic) do
+    t = Fabricate(:topic, category: documentation_category)
+    Fabricate(:post, topic: t, raw: "A topic with no links")
+    t
+  end
   fab!(:documentation_topic) do
     t = Fabricate(:topic, category: documentation_category)
     Fabricate(:post, topic: t)
@@ -30,120 +35,130 @@ describe BasicCategorySerializer do
   end
   fab!(:index_topic) do
     t = Fabricate(:topic, category: documentation_category)
-
-    Fabricate(:post, topic: t, raw: <<~MD)
-      Lorem ipsum dolor sit amet
-
-      ## General Usage
-
-      * No link
-      * [#{documentation_topic.title}](/t/#{documentation_topic.slug}/#{documentation_topic.id})
-      * #{documentation_topic2.slug}: [#{documentation_topic2.title}](/t/#{documentation_topic2.slug}/#{documentation_topic2.id})
-
-      ## Writing
-
-      * [#{documentation_topic3.title}](/t/#{documentation_topic3.slug}/#{documentation_topic3.id})
-      * #{documentation_topic4.slug}: [#{documentation_topic4.title}](/t/#{documentation_topic4.slug}/#{documentation_topic4.id})
-      * No link
-
-      ## Empty section
-
-    MD
-
+    Fabricate(:post, topic: t)
     t
   end
 
-  before do
-    SiteSetting.doc_categories_enabled = true
-
-    documentation_category.custom_fields[DocCategories::CATEGORY_INDEX_TOPIC] = index_topic.id
-    documentation_category.save!
+  fab!(:documentation_index) do
+    index = Fabricate(:doc_categories_index, category: documentation_category, index_topic:)
+    index
+      .sidebar_sections
+      .create!(position: 0, title: "General Usage")
+      .tap do |section|
+        section.sidebar_links.create!(
+          position: 0,
+          title: documentation_topic.title,
+          href: "/t/#{documentation_topic.slug}/#{documentation_topic.id}",
+        )
+        section.sidebar_links.create!(
+          position: 1,
+          title: documentation_topic2.slug,
+          href: "/t/#{documentation_topic2.slug}/#{documentation_topic2.id}",
+        )
+      end
+    index
+      .sidebar_sections
+      .create!(position: 1, title: "Writing")
+      .tap do |section|
+        section.sidebar_links.create!(
+          position: 0,
+          title: documentation_topic3.title,
+          href: "/t/#{documentation_topic3.slug}/#{documentation_topic3.id}",
+        )
+        section.sidebar_links.create!(
+          position: 1,
+          title: documentation_topic4.slug,
+          href: "/t/#{documentation_topic4.slug}/#{documentation_topic4.id}",
+        )
+      end
+    index
   end
 
-  context "#doc_category_index"
-  it "isn't serialized if the category is not a doc category" do
-    data = described_class.new(category, root: false).as_json
-    expect(data.has_key?(:doc_category_index)).to eq(false)
-  end
+  before { SiteSetting.doc_categories_enabled = true }
 
-  it "isn't serialized if the index topic doesn't exist" do
-    documentation_category.custom_fields[DocCategories::CATEGORY_INDEX_TOPIC] = 0
-    documentation_category.save!
+  describe "#doc_category_index" do
+    it "isn't serialized if the category is not a doc category" do
+      data = described_class.new(category, root: false).as_json
+      expect(data.has_key?(:doc_category_index)).to eq(false)
+    end
 
-    data = described_class.new(category, documentation_category: false).as_json
-    expect(data.has_key?(:doc_category_index)).to eq(false)
-  end
+    it "isn't serialized if the index topic doesn't exist" do
+      documentation_index.update_columns(index_topic_id: 0)
+      documentation_category.reload
 
-  it "isn't serialized if the index topic doesn't belong to the category" do
-    index_topic.category_id = category.id
-    index_topic.save!
+      data = described_class.new(category, documentation_category: false).as_json
+      expect(data.has_key?(:doc_category_index)).to eq(false)
+    end
 
-    data = described_class.new(category, documentation_category: false).as_json
-    expect(data.has_key?(:doc_category_index)).to eq(false)
-  end
+    it "isn't serialized if the index topic doesn't belong to the category" do
+      index_topic.update!(category: category)
+      documentation_category.reload
 
-  it "isn't serialized if the index topic doesn't belongs to a subcategory" do
-    index_topic.category_id = documentation_subcategory.id
-    index_topic.save!
+      data = described_class.new(category, documentation_category: false).as_json
+      expect(data.has_key?(:doc_category_index)).to eq(false)
+    end
 
-    data = described_class.new(category, documentation_category: false).as_json
-    expect(data.has_key?(:doc_category_index)).to eq(false)
-  end
+    it "isn't serialized if the index topic doesn't belongs to a subcategory" do
+      index_topic.update!(category: documentation_subcategory)
+      documentation_category.reload
 
-  it "isn't serialized if the index topic doesn't contain a first post" do
-    documentation_category.custom_fields[DocCategories::CATEGORY_INDEX_TOPIC] = Fabricate(:topic).id
-    documentation_category.save!
+      data = described_class.new(category, documentation_category: false).as_json
+      expect(data.has_key?(:doc_category_index)).to eq(false)
+    end
 
-    data = described_class.new(category, documentation_category: false).as_json
-    expect(data.has_key?(:doc_category_index)).to eq(false)
-  end
+    it "isn't serialized if the index topic doesn't contain a first post" do
+      empty_topic = Fabricate(:topic, category: documentation_category)
 
-  it "isn't serialized if the index topic doesn't contain the expected document structure to be parsed" do
-    documentation_category.custom_fields[
-      DocCategories::CATEGORY_INDEX_TOPIC
-    ] = documentation_topic.id
-    documentation_category.save!
+      documentation_index.update!(index_topic: empty_topic)
+      documentation_category.reload
 
-    data = described_class.new(category, documentation_category: false).as_json
-    expect(data.has_key?(:doc_category_index)).to eq(false)
-  end
+      data = described_class.new(category, documentation_category: false).as_json
+      expect(data.has_key?(:doc_category_index)).to eq(false)
+    end
 
-  it "is serialized as expected if the index topic can be parsed" do
-    data = described_class.new(documentation_category, root: false).as_json
+    it "isn't serialized if the topic index has no sections" do
+      documentation_index.update!(index_topic: empty_documentation_topic)
+      documentation_category.reload
 
-    parsed_index = data[:doc_category_index]
-    expect(parsed_index).to be_present
+      data = described_class.new(category, documentation_category: false).as_json
+      expect(data.has_key?(:doc_category_index)).to eq(false)
+    end
 
-    expect(parsed_index.size).to eq(2)
+    it "is serialized as expected if the index topic can be parsed" do
+      data = described_class.new(documentation_category, root: false).as_json
 
-    expect(parsed_index[0]["text"]).to eq("General Usage")
-    expect(parsed_index[0]["links"].size).to eq(2)
-    expect(parsed_index[0]["links"][0]).to eq(
-      {
-        text: documentation_topic.title,
-        href: "/t/#{documentation_topic.slug}/#{documentation_topic.id}",
-      }.as_json,
-    )
-    expect(parsed_index[0]["links"][1]).to eq(
-      {
-        text: documentation_topic2.slug,
-        href: "/t/#{documentation_topic2.slug}/#{documentation_topic2.id}",
-      }.as_json,
-    )
+      parsed_index = data[:doc_category_index]
+      expect(parsed_index.size).to eq(2)
 
-    expect(parsed_index[1]["text"]).to eq("Writing")
-    expect(parsed_index[1]["links"].size).to eq(2)
-    expect(parsed_index[1]["links"][0]).to eq(
-      {
-        text: documentation_topic3.title,
-        href: "/t/#{documentation_topic3.slug}/#{documentation_topic3.id}",
-      }.as_json,
-    )
-    expect(parsed_index[1]["links"][1]).to eq(
-      {
-        text: documentation_topic4.slug,
-        href: "/t/#{documentation_topic4.slug}/#{documentation_topic4.id}",
-      }.as_json,
-    )
+      expect(parsed_index[0]["text"]).to eq("General Usage")
+      expect(parsed_index[0]["links"].size).to eq(2)
+      expect(parsed_index[0]["links"][0]).to eq(
+        {
+          text: documentation_topic.title,
+          href: "/t/#{documentation_topic.slug}/#{documentation_topic.id}",
+        }.as_json,
+      )
+      expect(parsed_index[0]["links"][1]).to eq(
+        {
+          text: documentation_topic2.slug,
+          href: "/t/#{documentation_topic2.slug}/#{documentation_topic2.id}",
+        }.as_json,
+      )
+
+      expect(parsed_index[1]["text"]).to eq("Writing")
+      expect(parsed_index[1]["links"].size).to eq(2)
+      expect(parsed_index[1]["links"][0]).to eq(
+        {
+          text: documentation_topic3.title,
+          href: "/t/#{documentation_topic3.slug}/#{documentation_topic3.id}",
+        }.as_json,
+      )
+      expect(parsed_index[1]["links"][1]).to eq(
+        {
+          text: documentation_topic4.slug,
+          href: "/t/#{documentation_topic4.slug}/#{documentation_topic4.id}",
+        }.as_json,
+      )
+    end
   end
 end

--- a/spec/system/doc_category_sidebar_spec.rb
+++ b/spec/system/doc_category_sidebar_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Doc Category Sidebar", system: true do
+describe "Doc Category Sidebar", system: true do
   fab!(:admin)
   fab!(:category) { Fabricate(:category_with_definition) }
   fab!(:topic) { Fabricate(:topic_with_op, category: category) }
@@ -39,21 +39,65 @@ RSpec.describe "Doc Category Sidebar", system: true do
   let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
   let(:filter) { PageObjects::Components::Filter.new }
 
+  let(:default_sidebar_sections) do
+    [
+      {
+        title: "General Usage",
+        links: [
+          doc_link_for(documentation_topic),
+          doc_link_for(documentation_topic2, title: documentation_topic2.slug),
+        ],
+      },
+      {
+        title: "Writing",
+        links: [
+          doc_link_for(documentation_topic3),
+          doc_link_for(documentation_topic4, title: documentation_topic4.slug),
+        ],
+      },
+    ]
+  end
+
+  let!(:documentation_index) do
+    create_doc_categories_index(
+      category: documentation_category,
+      index_topic: index_topic,
+      sections: default_sidebar_sections,
+    )
+  end
+
   def docs_section_name(title)
     "discourse-docs-sidebar__#{Slug.for(title)}"
   end
 
-  def docs_link_name(title, section_title)
-    "#{docs_section_name(section_title)}___#{Slug.for(title)}"
+  def doc_link_for(topic, title: nil)
+    { title: title || topic.title, href: topic.relative_url, topic: topic }
+  end
+
+  def create_doc_categories_index(category:, index_topic:, sections: [])
+    DocCategories::Index
+      .create!(category: category, index_topic: index_topic)
+      .tap do |index|
+        sections.each_with_index do |section_data, section_position|
+          section =
+            index.sidebar_sections.create!(title: section_data[:title], position: section_position)
+
+          section_data[:links].each_with_index do |link_data, link_position|
+            section.sidebar_links.create!(
+              title: link_data[:title],
+              href: link_data[:href],
+              topic: link_data[:topic],
+              position: link_position,
+            )
+          end
+        end
+      end
   end
 
   before do
     SiteSetting.navigation_menu = "sidebar"
     SiteSetting.doc_categories_enabled = true
     Site.clear_cache
-
-    documentation_category.custom_fields[DocCategories::CATEGORY_INDEX_TOPIC] = index_topic.id
-    documentation_category.save!
   end
 
   context "when browsing regular pages" do
@@ -107,10 +151,20 @@ RSpec.describe "Doc Category Sidebar", system: true do
         * #{documentation_topic2.slug}: [#{documentation_topic2.title}](/t/#{documentation_topic2.slug}/#{documentation_topic2.id})
       MD
 
-      documentation_subcategory.custom_fields[
-        DocCategories::CATEGORY_INDEX_TOPIC
-      ] = subcategory_index_topic.id
-      documentation_subcategory.save!
+      create_doc_categories_index(
+        category: documentation_subcategory,
+        index_topic: subcategory_index_topic,
+        sections: [
+          {
+            title: "Subcategory Index",
+            links: [
+              doc_link_for(documentation_topic),
+              doc_link_for(documentation_topic2, title: documentation_topic2.slug),
+            ],
+          },
+        ],
+      )
+      Site.clear_cache
 
       visit("/c/#{documentation_category.slug}/#{documentation_category.id}")
 
@@ -121,6 +175,72 @@ RSpec.describe "Doc Category Sidebar", system: true do
 
       expect(sidebar).to be_visible
       expect(sidebar).to have_section(docs_section_name("Subcategory Index"))
+    end
+  end
+
+  context "when in category settings" do
+    before do
+      Jobs.run_immediately!
+      sign_in(admin)
+    end
+
+    it "correctly saves the new index topic" do
+      new_doc_topic = Fabricate(:topic_with_op, category: documentation_category)
+      another_doc_topic = Fabricate(:topic_with_op, category: documentation_category)
+      new_index_topic =
+        Fabricate(:topic, category: documentation_category).tap do |t|
+          Fabricate(:post, topic: t, raw: <<~MD)
+            ## Getting Started
+
+            * [#{new_doc_topic.title}](/t/#{new_doc_topic.slug}/#{new_doc_topic.id})
+
+            ## Additional Resources
+
+            * #{another_doc_topic.slug}: [#{another_doc_topic.title}](/t/#{another_doc_topic.slug}/#{another_doc_topic.id})
+          MD
+        end
+
+      SearchIndexer.enable
+      SearchIndexer.index(new_index_topic, force: true)
+
+      visit("/c/#{documentation_category.slug}/#{documentation_category.id}")
+      expect_docs_sidebar_to_be_correct
+
+      category_page = PageObjects::Pages::Category.new
+      category_page.visit_settings(documentation_category)
+
+      topic_chooser =
+        PageObjects::Components::SelectKit.new(
+          ".doc-categories-settings__index-topic .topic-chooser",
+        )
+      topic_chooser.expand
+      topic_chooser.search(new_index_topic.title)
+      topic_chooser.select_row_by_index(0)
+
+      category_page.save_settings
+      page.refresh
+
+      wait_for(timeout: Capybara.default_max_wait_time * 2) do
+        scroll_to(find(".doc-categories-settings__index-topic .topic-chooser"))
+        expect(topic_chooser).to have_selected_name(new_index_topic.title)
+      end
+      expect(topic_chooser.value).to eq(new_index_topic.id.to_s)
+
+      visit("/c/#{documentation_category.slug}/#{documentation_category.id}")
+
+      expect(sidebar).to be_visible
+      expect(sidebar).to have_section(docs_section_name("Getting Started"))
+      expect(sidebar).to have_section_link(
+        new_doc_topic.title,
+        href: %r{t/#{new_doc_topic.slug}/#{new_doc_topic.id}},
+      )
+      expect(sidebar).to have_section(docs_section_name("Additional Resources"))
+      expect(sidebar).to have_section_link(
+        another_doc_topic.slug,
+        href: %r{t/#{another_doc_topic.slug}/#{another_doc_topic.id}},
+      )
+      expect(sidebar).to have_no_section(docs_section_name("General Usage"))
+      expect(sidebar).to have_no_section(docs_section_name("Writing"))
     end
   end
 
@@ -203,6 +323,11 @@ RSpec.describe "Doc Category Sidebar", system: true do
       expect(site_wide_search[:href]).to end_with("/search?q=missing")
 
       # for subcategories
+      create_doc_categories_index(
+        category: documentation_subcategory,
+        index_topic: Fabricate(:topic, category: documentation_subcategory),
+        sections: [{ title: "Subcategory Docs", links: [doc_link_for(documentation_topic)] }],
+      )
       visit(
         "/c/#{documentation_category.slug}/#{documentation_subcategory.slug}/#{documentation_subcategory.id}",
       )
@@ -215,6 +340,11 @@ RSpec.describe "Doc Category Sidebar", system: true do
 
       # for 3 levels deep
       visit("/c/#{documentation_subsubcategory.id}")
+      create_doc_categories_index(
+        category: documentation_subsubcategory,
+        index_topic: Fabricate(:topic, category: documentation_subsubcategory),
+        sections: [{ title: "Third Level Docs", links: [doc_link_for(documentation_topic)] }],
+      )
       filter.filter("missing")
 
       suggested_category_search = page.find(".docs-sidebar-suggested-category-search")

--- a/spec/system/doc_category_sidebar_spec.rb
+++ b/spec/system/doc_category_sidebar_spec.rb
@@ -214,20 +214,18 @@ describe "Doc Category Sidebar", system: true do
           ".doc-categories-settings__index-topic .topic-chooser",
         )
       topic_chooser.expand
-      topic_chooser.search(new_index_topic.title)
+      topic_chooser.search(new_index_topic.id)
       topic_chooser.select_row_by_index(0)
 
       category_page.save_settings
-      wait_for do
-        expect(DocCategories::Index.find_by(category: documentation_category).index_topic).to eq(
-          new_index_topic,
-        )
-      end
+      expect(category_page.find("#save-category")).to have_content(I18n.t("js.saving"))
+      expect(category_page.find("#save-category")).to have_content(I18n.t("js.category.save"))
+      expect(topic_chooser).to have_selected_name(new_index_topic.title)
 
       page.refresh
+      scroll_to(find(".doc-categories-settings__index-topic .topic-chooser"))
 
-      wait_for(timeout: Capybara.default_max_wait_time * 3) do
-        scroll_to(find(".doc-categories-settings__index-topic .topic-chooser"))
+      wait_for(timeout: Capybara.default_max_wait_time * 2) do
         expect(topic_chooser).to have_selected_name(new_index_topic.title)
       end
       expect(topic_chooser.value).to eq(new_index_topic.id.to_s)

--- a/spec/system/doc_category_sidebar_spec.rb
+++ b/spec/system/doc_category_sidebar_spec.rb
@@ -218,9 +218,15 @@ describe "Doc Category Sidebar", system: true do
       topic_chooser.select_row_by_index(0)
 
       category_page.save_settings
+      wait_for do
+        expect(DocCategories::Index.find_by(category: documentation_category).index_topic).to eq(
+          new_index_topic,
+        )
+      end
+
       page.refresh
 
-      wait_for(timeout: Capybara.default_max_wait_time * 2) do
+      wait_for(timeout: Capybara.default_max_wait_time * 3) do
         scroll_to(find(".doc-categories-settings__index-topic .topic-chooser"))
         expect(topic_chooser).to have_selected_name(new_index_topic.title)
       end


### PR DESCRIPTION
This PR
- migrates `doc_category_index` topics from using `category_custom_fields` to a dedicated `doc_categories_indexes` table
  - uses https://github.com/discourse/discourse/commit/eb40b4f9801ebfa35310a72d50ba59459586aeb6 and https://github.com/discourse/discourse/commit/ae97fb18658593830a2f4c25eb52e479a6376d28
  - since there's an existing compat line on the same version, there's no need to add one
- moves events to use https://github.com/discourse/discourse-doc-categories/pull/50
- populates sidebar using the new models
- preloads doc category index associations when fetching categories

This PR also includes a rake task (`doc_categories.rake`) for rebuilding sidebar sections and links from active doc index topics -- this is not exactly recommended to do in a migration as it would involve either using the parser or nokogiri (which implementations can drift and cause an invalid migration).