### PR TITLE
DEV: Make sure rake task reloads model before count

### DIFF
--- a/lib/tasks/doc_categories.rake
+++ b/lib/tasks/doc_categories.rake
@@ -9,9 +9,11 @@ namespace :doc_categories do
       .includes(:category)
       .find_each do |index|
         category = index.category
-        puts "Processing category ##{category.id} (#{category.name})"
+        puts "Processing category ##{category.id} - #{category.name}"
         DocCategories::IndexStructureRefresher.new(category.id).refresh!
+        index.reload
         puts " ⮑  Created #{index.sidebar_sections.count} sections and #{index.sidebar_sections.sum { |section| section.sidebar_links.count }} links"
+        puts ""
       rescue => e
         puts "Failed to process category ##{category.id}: #{e.message}"
       end


### PR DESCRIPTION
The current output is 

```
Processing category #39 (Doc Sub)
 ⮑  Created 2 sections and 0 links
Processing category #29 (Docs)
 ⮑  Created 2 sections and 0 links
 ```

links are 0 as the model isn't reloaded.

Changing to

```
Processing category #39 - Doc Sub
 ⮑  Created 2 sections and 4 links

Processing category #29 - Docs
 ⮑  Created 2 sections and 6 links
 ```