### PR TITLE
FIX: Ensure PMs are handled when moving index topics

### DIFF
--- a/lib/doc_categories/initializers/handle_post_changes.rb
+++ b/lib/doc_categories/initializers/handle_post_changes.rb
@@ -30,7 +30,8 @@ module ::DocCategories
         prev_id, curr_id = revisor.topic_diff["category_id"]
 
         # topic is moved into a doc category which it is the index for
-        if curr_id == current_category.id && doc_index_topic?(topic, current_category)
+        if current_category && curr_id == current_category.id &&
+             doc_index_topic?(topic, current_category)
           enqueue_refresh(curr_id)
           return
         end

--- a/spec/lib/initializers/handle_post_changes_spec.rb
+++ b/spec/lib/initializers/handle_post_changes_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 describe DocCategories::Initializers::HandlePostChanges do
-  fab!(:documentation_category) { Fabricate(:category_with_definition) }
-  fab!(:other_category) { Fabricate(:category_with_definition) }
+  fab!(:documentation_category, :category_with_definition)
+  fab!(:other_category, :category_with_definition)
   fab!(:index_topic) do
     Fabricate(:topic, category: documentation_category).tap { |topic| Fabricate(:post, topic:) }
   end
@@ -36,6 +36,12 @@ describe DocCategories::Initializers::HandlePostChanges do
     expect_not_enqueued_with(job: :doc_categories_refresh_index) do
       revise(other_topic.first_post, raw: "Changed")
     end
+  end
+
+  it "does not clear cache when topic is revised to PM" do
+    expect {
+      revise(index_topic.first_post, archetype: Archetype.private_message, category_id: nil)
+    }.not_to raise_error
   end
 
   it "clears the index and refreshes the index's category when the index topic moves" do


### PR DESCRIPTION
While the plugin is enabled, when making any topic a PM, it currently errors out due to the absence of a `category.id`.

This PR fixes that.