### PR TITLE
DEV: Add learn more url for simple mode upcoming change

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,6 +11,7 @@ doc_categories:
     upcoming_change:
       status: "experimental"
       impact: "other,all_members"
+      learn_more_url: "https://meta.discourse.org/t/-/403366"
   doc_categories_homepage:
     default: ""
     client: true


### PR DESCRIPTION
Adds the learn_more_url for the doc_categories_simple_mode upcoming
change, pointing to the announcement topic on Meta.

https://meta.discourse.org/t/introducing-simple-mode-for-discourse-doc-categories/403366