### PR TITLE
UX: fix date position on OP for suggested edits compatibility

### DIFF
--- a/assets/stylesheets/common.scss
+++ b/assets/stylesheets/common.scss
@@ -60,16 +60,29 @@ body.doc-simple-mode {
       display: none;
     }
 
+    .topic-body {
+      padding-top: 0;
+    }
+
     .topic-meta-data .names {
       display: none;
     }
 
-    .topic-meta-data .post-infos {
-      position: absolute;
-      right: 0;
-      top: 0;
-      transform: translateY(-100%);
-      margin-top: -1em;
+    .topic-meta-data {
+      padding-block: 0;
+      font-size: var(--font-down-1);
+
+      .post-infos {
+        justify-content: end;
+      }
+    }
+
+    .boxed .contents {
+      padding-top: 0;
+    }
+
+    .cooked {
+      padding-top: 0;
     }
 
     .topic-body {

--- a/assets/stylesheets/common.scss
+++ b/assets/stylesheets/common.scss
@@ -71,6 +71,7 @@ body.doc-simple-mode {
     .topic-meta-data {
       padding-block: 0;
       font-size: var(--font-down-1);
+      justify-content: end;
 
       .post-infos {
         justify-content: end;


### PR DESCRIPTION
The absolutely positioned date just isn't going to work here, there are too many variables... it can overlap tags, overlap suggested edit banner, etc 

the extra space is a little annoying, but we need the predictability of position 

before:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/3a8c8359-d953-4687-9d2e-db25e15b565d" />


after:
<img width="1420" height="590" alt="image" src="https://github.com/user-attachments/assets/9072c5fb-2750-41a3-ba5b-9d411d0eb48d" />
