### PR TITLE
UX: expand all replies after posting one

### DIFF
--- a/assets/javascripts/discourse/initializers/doc-categories.gjs
+++ b/assets/javascripts/discourse/initializers/doc-categories.gjs
@@ -9,7 +9,6 @@ import DocCategorySidebarPanel from "../lib/doc-category-sidebar-panel";
 import {
   attachNewPostInterceptor,
   collapseStream,
-  expandStream,
   getState,
   inDocSimpleMode,
 } from "../lib/simple-mode";
@@ -93,7 +92,13 @@ export default {
         }
       );
 
-      api.onAppEvent("post:created", (post) => {
+      // Own replies should be visible immediately rather than flashing and
+      // then getting swallowed back behind "Show xx comments". While
+      // collapsed, the stream only has the OP loaded, so committing a reply
+      // several posts ahead (post_number-wise) leaves a gap of un-fetched
+      // posts between the OP and the new reply. Force an authoritative
+      // reload of that window instead of trying to reconstruct it locally.
+      api.onAppEvent("post:created", async (post) => {
         const postStream =
           post.topic?.postStream ??
           container.lookup("controller:topic")?.model?.postStream;
@@ -106,7 +111,21 @@ export default {
 
         const state = getState(postStream);
         if (state.expanded === false) {
-          expandStream(postStream);
+          const index = postStream.posts.indexOf(post);
+          const previousPost = index > 0 ? postStream.posts[index - 1] : null;
+          const hasGap =
+            previousPost && post.post_number > previousPost.post_number + 1;
+
+          state.hiddenIds = [];
+          state.hiddenCount = 0;
+          state.expanded = true;
+
+          if (hasGap) {
+            await postStream.refresh({
+              nearPost: post.post_number,
+              forceLoad: true,
+            });
+          }
         }
 
         schedule("afterRender", () => {

--- a/assets/javascripts/discourse/initializers/doc-categories.gjs
+++ b/assets/javascripts/discourse/initializers/doc-categories.gjs
@@ -1,3 +1,5 @@
+import { schedule } from "@ember/runloop";
+import DiscourseURL from "discourse/lib/url";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import DocCategorySettings from "../components/doc-category-settings";
 import DocCategorySettingsForm from "../components/doc-category-settings-form";
@@ -7,6 +9,7 @@ import DocCategorySidebarPanel from "../lib/doc-category-sidebar-panel";
 import {
   attachNewPostInterceptor,
   collapseStream,
+  expandStream,
   getState,
   inDocSimpleMode,
 } from "../lib/simple-mode";
@@ -89,6 +92,27 @@ export default {
           return tabs.filter((tab) => tab.id !== "suggested-topics");
         }
       );
+
+      api.onAppEvent("post:created", (post) => {
+        const postStream =
+          post.topic?.postStream ??
+          container.lookup("controller:topic")?.model?.postStream;
+        if (
+          !postStream ||
+          !inDocSimpleMode(siteSettings, postStream.topic?.category)
+        ) {
+          return;
+        }
+
+        const state = getState(postStream);
+        if (state.expanded === false) {
+          expandStream(postStream);
+        }
+
+        schedule("afterRender", () => {
+          DiscourseURL.jumpToPost(post.post_number, { jumpEnd: true });
+        });
+      });
 
       api.renderAfterWrapperOutlet("post-links", DocSimpleModeToggle);
     });

--- a/assets/javascripts/discourse/lib/simple-mode.js
+++ b/assets/javascripts/discourse/lib/simple-mode.js
@@ -71,11 +71,10 @@ export function expandStream(postStream) {
 
   postStream.stream.splice(0, postStream.stream.length, ...fullStream);
 
-  // Posts other than the OP are lazy-loaded as the user scrolls; we only need
-  // to ensure the OP is still present in the `posts` array.
-  if (!postStream.posts.find((p) => p.post_number === 1)) {
-    postStream.posts.splice(0, postStream.posts.length, opPost);
-  }
+  const restoredPosts = fullStream
+    .map((id) => postStream.findLoadedPost(id))
+    .filter(Boolean);
+  postStream.posts.splice(0, postStream.posts.length, ...restoredPosts);
 
   state.hiddenIds = [];
   state.hiddenCount = 0;

--- a/assets/javascripts/discourse/lib/simple-mode.js
+++ b/assets/javascripts/discourse/lib/simple-mode.js
@@ -71,10 +71,9 @@ export function expandStream(postStream) {
 
   postStream.stream.splice(0, postStream.stream.length, ...fullStream);
 
-  const restoredPosts = fullStream
-    .map((id) => postStream.findLoadedPost(id))
-    .filter(Boolean);
-  postStream.posts.splice(0, postStream.posts.length, ...restoredPosts);
+  if (!postStream.posts.find((p) => p.post_number === 1)) {
+    postStream.posts.splice(0, postStream.posts.length, opPost);
+  }
 
   state.hiddenIds = [];
   state.hiddenCount = 0;

--- a/spec/system/simple_mode_spec.rb
+++ b/spec/system/simple_mode_spec.rb
@@ -118,6 +118,21 @@ describe "Doc Categories Simple Mode" do
     expect(page).to have_css("[data-post-number='4']")
   end
 
+  it "expands and shows the user's own reply immediately after posting" do
+    topic_page.visit_topic(documentation_topic)
+
+    expect(toggle).to have_show_comments_button(count: 3)
+
+    topic_page.click_reply_button
+    topic_page.send_reply("This is my own new reply")
+
+    expect(page).to have_css("[data-post-number='5']", text: "This is my own new reply")
+    expect(toggle).to have_hide_comments_button
+    expect(page).to have_css("[data-post-number='2']")
+    expect(page).to have_css("[data-post-number='3']")
+    expect(page).to have_css("[data-post-number='4']")
+  end
+
   it "resets comments state when navigating between doc topics" do
     topic_page.visit_topic(documentation_topic)
 

--- a/test/javascripts/integration/components/doc-simple-mode-toggle-test.gjs
+++ b/test/javascripts/integration/components/doc-simple-mode-toggle-test.gjs
@@ -137,10 +137,10 @@ module("Integration | Component | doc-simple-mode-toggle", function (hooks) {
       [100, 101, 102, 103],
       "stream is restored to the original"
     );
-    assert.strictEqual(
-      postStream.posts.length,
-      1,
-      "only the OP stays in posts (other posts are lazy-loaded)"
+    assert.deepEqual(
+      postStream.posts.map((p) => p.id),
+      [100, 101, 102, 103],
+      "posts are restored from the identity map"
     );
 
     await click(".doc-simple-mode-toggle__button");

--- a/test/javascripts/integration/components/doc-simple-mode-toggle-test.gjs
+++ b/test/javascripts/integration/components/doc-simple-mode-toggle-test.gjs
@@ -137,10 +137,10 @@ module("Integration | Component | doc-simple-mode-toggle", function (hooks) {
       [100, 101, 102, 103],
       "stream is restored to the original"
     );
-    assert.deepEqual(
-      postStream.posts.map((p) => p.id),
-      [100, 101, 102, 103],
-      "posts are restored from the identity map"
+    assert.strictEqual(
+      postStream.posts.length,
+      1,
+      "only the OP stays in posts (other posts are lazy-loaded)"
     );
 
     await click(".doc-simple-mode-toggle__button");


### PR DESCRIPTION
Currently after you post a reply on a docs topic when the upcoming change `Doc categories simple mode` is enabled, you see a flash of the replies and they're hidden again. It's more natural to see all replies expanded so you can see your own in context. 