### PR TITLE
DEV: Update specs for themeable navigation menu

### DIFF
--- a/spec/requests/docs_legacy_controller_spec.rb
+++ b/spec/requests/docs_legacy_controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ::DocCategories::DocsLegacyController do
   before do
     GlobalSetting.stubs(:docs_path).returns("docs")
 
-    SiteSetting.navigation_menu = "sidebar"
     SiteSetting.doc_categories_enabled = true
     SiteSetting.doc_categories_homepage = "/redirect-test"
   end

--- a/spec/system/doc_category_sidebar_spec.rb
+++ b/spec/system/doc_category_sidebar_spec.rb
@@ -77,6 +77,14 @@ describe "Doc Category Sidebar" do
     { title: title || topic.title, href: href, topic: topic }
   end
 
+  def set_navigation_menu(value)
+    if SiteSetting.themeable[:navigation_menu]
+      Fabricate(:theme_site_setting_with_service, name: "navigation_menu", value:)
+    else
+      SiteSetting.navigation_menu = value
+    end
+  end
+
   def create_doc_categories_index(category:, index_topic:, sections: [])
     DocCategories::Index
       .create!(category: category, index_topic: index_topic)
@@ -98,7 +106,7 @@ describe "Doc Category Sidebar" do
   end
 
   before do
-    SiteSetting.navigation_menu = "sidebar"
+    set_navigation_menu("sidebar")
     SiteSetting.doc_categories_enabled = true
     Site.clear_cache
   end
@@ -110,6 +118,25 @@ describe "Doc Category Sidebar" do
 
       visit("/t/#{topic.slug}/#{topic.id}")
       expect(sidebar).to have_section("categories")
+    end
+  end
+
+  context "when using header dropdown navigation" do
+    let(:sidebar_dropdown) { PageObjects::Components::SidebarHeaderDropdown.new }
+
+    before { set_navigation_menu("header dropdown") }
+
+    it "displays the docs navigation in the header dropdown" do
+      visit("/c/#{documentation_category.slug}/#{documentation_category.id}")
+
+      expect(sidebar).to be_not_visible
+
+      sidebar_dropdown.click
+      expect(sidebar_dropdown).to be_visible
+      expect_docs_sidebar_to_be_correct
+
+      page.find(".sidebar-section-link", text: documentation_topic.title).click
+      expect(page).to have_current_path(documentation_topic.relative_url)
     end
   end
 

--- a/spec/system/docs_legacy_compatibility_redirects_spec.rb
+++ b/spec/system/docs_legacy_compatibility_redirects_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe "Docs Category Sidebar" do
   before do
     GlobalSetting.stubs(:docs_path).returns("docs")
 
-    SiteSetting.navigation_menu = "sidebar"
     SiteSetting.doc_categories_enabled = true
     SiteSetting.doc_categories_homepage = "/c/#{category.slug}/#{category.id}"
   end


### PR DESCRIPTION
[discourse/discourse#42068](https://github.com/discourse/discourse/pull/42068) makes `navigation_menu` a themeable site setting. Specs running against that change must configure it through the theme-site-setting service.

The documentation index uses Discourse’s sidebar-panel system in both navigation modes. It appears persistently when the active theme uses sidebar navigation and inside the hamburger menu when the theme uses header dropdown navigation.

This change keeps that behavior explicit while supporting current core and the proposed change. It configures `navigation_menu` through `theme_site_setting_with_service` when the setting is themeable, and retains the current direct assignment while it remains a global site setting.

The legacy redirect request and system specs do not exercise navigation behavior, so this change removes their redundant `navigation_menu` setup.

This lets the plugin update land against current core before the core change, while keeping the core PR’s official-plugin test jobs compatible.